### PR TITLE
FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
＃这些是支持的资助模型平台

github：＃替换最多4个启用GitHub赞助商的用户名，例如[user1，user2]
patreon：＃替换为一个Patreon用户名
open_collective：＃替换为一个Open Collective用户名
ko_fi：＃替换为单个Ko-fi用户名
tidelift：＃替换为单个Tidelift平台名称/包名称，例如，npm / babel
community_bridge：＃替换为单个Community Bridge项目名称，例如，cloud-foundry
liberapay：＃替换为一个Liberapay用户名
issuehunt：＃替换为一个IssueHunt用户名
otechie：＃替换为一个Otechie用户名
自定义：＃替换最多4个自定义赞助网址，例如['link1'，'link2']